### PR TITLE
Add mc_state_observation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,21 @@ if(WITH_ROS_SUPPORT)
   )
 endif()
 
+if(WITH_ROS_SUPPORT)
+  AddProject(gram_savitzky_golay
+    GITHUB arntanguy/gram_savitzky_golay
+    GIT_TAG origin/master
+  )
+  set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=ON")
+else()
+  set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=OFF")
+endif()
+AddProject(mc_state_observation
+  GITHUB jrl-umi3218/mc_state_observation
+  CMAKE_ARGS ${MC_STATE_OBSERVATION_ROS_OPTION}
+  DEPENDS mc_rtc
+)
+
 add_subdirectory(robots)
 
 file(GLOB extension_dirs CONFIGURE_DEPENDS "extensions/*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,21 +177,23 @@ if(WITH_ROS_SUPPORT)
   )
 endif()
 
+set(MC_STATE_OBSERVATION_DEPENDS mc_rtc)
+set(MC_STATE_OBSERVATION_OPTIONS "-DWITH_ROS_OBSERVERS=OFF")
+
 if(WITH_ROS_SUPPORT)
   AddProject(gram_savitzky_golay
     GITHUB arntanguy/gram_savitzky_golay
     GIT_TAG origin/master
   )
-  set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=ON")
-  set(MC_STATE_OBSERVATION_ROS_DEPENDS "gram_savitzky_golay")
-else()
-  set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=OFF")
-  set(MC_STATE_OBSERVATION_ROS_DEPENDS)
+  list(APPEND MC_STATE_OBSERVATION_DEPENDS gram_savitzky_golay)
+  set(MC_STATE_OBSERVATION_OPTIONS "-DWITH_ROS_OBSERVERS=ON")
+  AptInstall(ros-${ROS_DISTRO}-tf2-eigen)
 endif()
+
 AddProject(mc_state_observation
   GITHUB jrl-umi3218/mc_state_observation
-  CMAKE_ARGS ${MC_STATE_OBSERVATION_ROS_OPTION}
-  DEPENDS mc_rtc ${MC_STATE_OBSERVATION_ROS_DEPENDS}
+  CMAKE_ARGS ${MC_STATE_OBSERVATION_OPTIONS}
+  DEPENDS ${MC_STATE_OBSERVATION_DEPENDS}
 )
 
 add_subdirectory(robots)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,13 +183,15 @@ if(WITH_ROS_SUPPORT)
     GIT_TAG origin/master
   )
   set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=ON")
+  set(MC_STATE_OBSERVATION_ROS_DEPENDS "gram_savitzky_golay")
 else()
   set(MC_STATE_OBSERVATION_ROS_OPTION "-DWITH_ROS_OBSERVERS=OFF")
+  set(MC_STATE_OBSERVATION_ROS_DEPENDS)
 endif()
 AddProject(mc_state_observation
   GITHUB jrl-umi3218/mc_state_observation
   CMAKE_ARGS ${MC_STATE_OBSERVATION_ROS_OPTION}
-  DEPENDS mc_rtc
+  DEPENDS mc_rtc ${MC_STATE_OBSERVATION_ROS_DEPENDS}
 )
 
 add_subdirectory(robots)


### PR DESCRIPTION
Attitude observer in mc_state_observation is now a component that should be installed as standard.
(Or perhaps we could move the Attitude observer to `mc_rtc/src/mc_observers`).