### PR TITLE
[HRP4] Use new HRP4 model/module repositories

### DIFF
--- a/robots/HRP4.cmake
+++ b/robots/HRP4.cmake
@@ -4,14 +4,14 @@ if(NOT WITH_HRP4)
   return()
 endif()
 
-AddCatkinProject(hrp4
-  GITE mc-hrp4/hrp4
-  GIT_TAG origin/master
+AddCatkinProject(hrp4_description
+  GITHUB_PRIVATE isri-aist/hrp4_description
+  GIT_TAG origin/main
   WORKSPACE data_ws
 )
 
 AddProject(mc-hrp4
-  GITE mc-hrp4/mc-hrp4
-  GIT_TAG origin/master
-  DEPENDS hrp4 mc_rtc
+  GITHUB_PRIVATE isri-aist/mc-hrp4
+  GIT_TAG origin/main
+  DEPENDS hrp4_description mc_rtc
 )


### PR DESCRIPTION
This PR changes the repositories used for the HRP4LIRMM robot from their former version on gite to a brand new version on isri-aist. This is a full rewrite of the robot models and module, the intent is to avoid duplication between the VRML models and urdf:
- The VRML model has been upgraded to include missing information (torques and velocity limits)
- Variants of HRP4LIRMM grippers can be generated from a common main model. We have the default hand grippers, the impact gripper currently mounted on the robot, and the former COMANOID gripper)
- The corresponding URDF file is generated from the VRML automatically, except for the COMANOID gripper since I could not find an easy way to automatically convert the prismatic joint of the gripper. All former models and their corresponding robot modules are nonetheless provided as legacy should the need arise to revive them.
- The robot modules implements all variants currently in use

See:
- https://github.com/isri-aist/mc-hrp4
- https://github.com/isri-aist/HRP4LIRMM
- https://github.com/isri-aist/hrp4_description

These new models have been extensively used, including for walking ([CDADance](https://github.com/arntanguy/CDADance) demo) and for Hugo's paper demo.