### PR TITLE
[Panda] Build mc_franka when building WITH_Panda

### DIFF
--- a/robots/Panda.cmake
+++ b/robots/Panda.cmake
@@ -37,3 +37,9 @@ AddProject(mc_panda
   GIT_TAG origin/master
   DEPENDS mc_rtc ${mc_panda_DEPENDS}
 )
+
+AddProject(mc_franka
+  GITHUB jrl-umi3218/mc_franka
+  GIT_TAG origin/master
+  DEPENDS mc_rtc mc_panda
+)


### PR DESCRIPTION
This PR adds support for `MCFrankaControl` when building with the `Panda` robot.
Some post installation steps are required from the user for this to work (see https://github.com/jrl-umi3218/mc_franka readme).