### PR TITLE
[panda] Add support for PandaLIRMM

### DIFF
--- a/robots/Panda.cmake
+++ b/robots/Panda.cmake
@@ -1,4 +1,8 @@
 option(WITH_Panda "Build Franka Emika Panda support" OFF)
+option(WITH_PandaLIRMM "Build Panda support for LIRMM robots" OFF)
+if(WITH_PandaLIRMM AND NOT WITH_Panda)
+  message(FATAL_ERROR "Panda LIRMM support requires Panda support")
+endif()
 
 set(Panda_DEPENDENCIES_FROM_SOURCE_DEFAULT ON)
 if(DPKG AND WITH_ROS_SUPPORT)
@@ -43,3 +47,11 @@ AddProject(mc_franka
   GIT_TAG origin/master
   DEPENDS mc_rtc mc_panda
 )
+
+if(WITH_PandaLIRMM)
+  AddProject(mc_panda_lirmm
+    GITHUB jrl-umi3218/mc_panda_lirmm
+    GIT_TAG origin/main
+    DEPENDS mc_panda
+  )
+endif()


### PR DESCRIPTION
This adds optional support for [mc_panda_lirmm](https://github.com/jrl-umi3218/mc_panda_lirmm) modules used for the panda robots in LIRMM.
Turn on with `WITH_Panda=ON` and `WITH_PandaLIRMM=ON`.