### PR TITLE
Fix wrong closing of summary.

### DIFF
--- a/doc/devcontainer.md
+++ b/doc/devcontainer.md
@@ -139,7 +139,7 @@ By default the following folders are mounted within the container:
 </details>
 
 <details>
-  <summary>Build within the terminal<summary>
+  <summary>Build within the terminal</summary>
   You can now build from the terminal, or use VSCode's "CMake Tools" extension to select your desired build preset.
   Note that default presets will:
   - clone all projects in `./devel`


### PR DESCRIPTION
The documentation on devcontainer related to compiling with devpod is wrongly display.
This is due to a wrongly close summary section.
This PR fix this simple matter.