### PR TITLE
PR to update robots/Talos.cmake

### DIFF
--- a/doc/devcontainer.md
+++ b/doc/devcontainer.md
@@ -139,7 +139,7 @@ By default the following folders are mounted within the container:
 </details>
 
 <details>
-  <summary>Build within the terminal<summary>
+  <summary>Build within the terminal</summary>
   You can now build from the terminal, or use VSCode's "CMake Tools" extension to select your desired build preset.
   Note that default presets will:
   - clone all projects in `./devel`

--- a/robots/Talos.cmake
+++ b/robots/Talos.cmake
@@ -4,7 +4,6 @@ if(NOT WITH_Talos)
   return()
 endif()
 
-
 AddCatkinProject(
   pal_urdf_utils
   GITHUB pal-robotics/pal_urdf_utils

--- a/robots/Talos.cmake
+++ b/robots/Talos.cmake
@@ -4,10 +4,18 @@ if(NOT WITH_Talos)
   return()
 endif()
 
+
+AddCatkinProject(
+  pal_urdf_utils
+  GITHUB pal-robotics/pal_urdf_utils
+  GIT_TAG origin/humble-devel
+  WORKSPACE data_ws
+)
+
 AddCatkinProject(
   talos_robot
   GITHUB pal-robotics/talos_robot
-  GIT_TAG origin/kinetic-devel
+  GIT_TAG origin/humble-devel
   WORKSPACE data_ws
 )
 


### PR DESCRIPTION
This PR is an update to provide TALOS in mc_rtc.

In order to use https://github.com/jrl-umi3218/mc-talos with humble-devel compatibility it is necessary to update the dependency with `pal_urdf_utils` and update the branch for the repository `talos_robot`.

This PR implements this.