### PR TITLE
feat(panda): Update libfranka for ubuntu 22.04

### DIFF
--- a/robots/Panda.cmake
+++ b/robots/Panda.cmake
@@ -11,54 +11,42 @@ if(WITH_PandaLIRMM AND NOT WITH_Panda)
   )
 endif()
 
-set(Panda_DEPENDENCIES_FROM_SOURCE_DEFAULT ON)
-if(DPKG AND WITH_ROS_SUPPORT)
-  set(Panda_DEPENDENCIES_FROM_SOURCE_DEFAULT OFF)
-endif()
-cmake_dependent_option(
-  Panda_DEPENDENCIES_FROM_SOURCE "Install Panda dependencies from source"
-  ${Panda_DEPENDENCIES_FROM_SOURCE_DEFAULT} "WITH_Panda" OFF
-)
-
 if(NOT WITH_Panda)
   return()
 endif()
 
-if(Panda_DEPENDENCIES_FROM_SOURCE)
-  AddProject(
-    libfranka
-    GITHUB frankaemika/libfranka
-    GIT_TAG origin/0.8.0
-  )
-  set(mc_panda_DEPENDS libfranka)
-  if(WITH_ROS_SUPPORT)
-    AddCatkinProject(
-      franka_ros
-      GITHUB frankaemika/franka_ros
-      GIT_TAG origin/0.8.1
-      WORKSPACE mc_rtc_ws
-      DEPENDS libfranka
-    )
-    list(APPEND mc_panda_DEPENDS franka_ros)
-  endif()
-else()
-  if(NOT DPKG OR NOT WITH_ROS_SUPPORT)
-    message(
-      FATAL_ERROR
-        "Panda dependencies binaries are only available from ROS APT mirrors, set Panda_DEPENDENCIES_FROM_SOURCE to OFF"
-    )
-  endif()
-  AptInstall(ros-${ROS_DISTRO}-libfranka ros-${ROS_DISTRO}-franka-description)
-endif()
+# See https://frankarobotics.github.io/docs/compatibility.html for compatibility between server on the robot/libfranka client
+# For robots using FER 4.2.2, we are limited to <0.10.0, with 0.9.2 being the latest published tag
+AddProject(
+  libfranka
+  GITHUB frankarobotics/libfranka
+  GIT_TAG 0.9.2
+  APT_DEPENDENCIES libtinyxml2-dev libpoco-dev
+  CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_EXAMPLES=ON
+)
+set(mc_panda_DEPENDS libfranka)
 
-if(WITH_MC_FRANKA)
-  AptInstall(libcap2-bin) # for setcap
-  AddProject(
-    mc_franka
-    GITHUB jrl-umi3218/mc_franka
-    GIT_TAG origin/master
-    DEPENDS mc_rtc mc_panda
+if(WITH_ROS_SUPPORT)
+  AddCatkinProject(
+    franka_description
+    GITHUB frankarobotics/franka_description
+    GIT_TAG origin/main
+    WORKSPACE mc_rtc_ws
+    DEPENDS libfranka
   )
+  list(APPEND mc_panda_DEPENDS franka_description)
+
+  # XXX: this is now incompatible with libfranka <0.10 which we require
+  # to run on our older robots
+  #
+  # AddCatkinProject(
+  #   franka_ros2
+  #   GITHUB frankarobotics/franka_ros2
+  #   GIT_TAG origin/humble
+  #   WORKSPACE mc_rtc_ws
+  #   DEPENDS libfranka
+  # )
+  # list(APPEND mc_panda_DEPENDS franka_ros2)
 endif()
 
 AddProject(
@@ -74,5 +62,15 @@ if(WITH_PandaLIRMM)
     GITHUB jrl-umi3218/mc_panda_lirmm
     GIT_TAG origin/main
     DEPENDS mc_panda
+  )
+endif()
+
+if(WITH_MC_FRANKA)
+  AptInstall(libcap2-bin) # for setcap
+  AddProject(
+    mc_franka
+    GITHUB jrl-umi3218/mc_franka
+    GIT_TAG origin/master
+    DEPENDS mc_rtc mc_panda
   )
 endif()


### PR DESCRIPTION
This PR upgrades libfranka to support ubuntu 22.04:

For robots using FER 4.2.2, we are limited to <0.10.0, with 0.9.2 being the latest published tag. On LIRMM robots we cannot upgrade to the newest franka research interface and are stuck here. As far as I can tell this is the last available version of FER before they upgraded to using Franka Research 3 interface. ROS humble official packages for libfranka only support Franka Research 3, and as such we cannot use them. If ROS support is required, there seems to be workarounds in unsupported repositories, but I haven't investigated further.

Thus:
- We install libfranka 0.9.2 from source
- panda_description is the one installed by mc_panda
- Add an option to build MCFrankaControl from mc_franka

 See https://frankarobotics.github.io/docs/compatibility.html for compatibility between server on the robot/libfranka client
